### PR TITLE
Fix command fails on /spawnmob [name] and /item [prefixName]

### DIFF
--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -343,17 +343,13 @@ namespace TShockAPI
 		{
 			var found = new List<NPC>();
 			NPC npc = new NPC();
-			string nameLower = name.ToLowerInvariant();
+			string nameLower = name.ToLower();
 			for (int i = -17; i < Main.maxNPCTypes; i++)
 			{
-				string englishName = EnglishLanguage.GetNpcNameById(i).ToLowerInvariant();
-
-				npc.SetDefaults(i);
-				if (npc.FullName.ToLowerInvariant() == nameLower || npc.TypeName.ToLowerInvariant() == nameLower
-					|| nameLower == englishName)
+				npc.netDefaults(i);
+				if (npc.name.ToLower() == nameLower)
 					return new List<NPC> { npc };
-				if (npc.FullName.ToLowerInvariant().StartsWith(nameLower) || npc.TypeName.ToLowerInvariant().StartsWith(nameLower)
-					|| englishName?.StartsWith(nameLower) == true)
+				if (npc.name.ToLower().StartsWith(namelower))
 					found.Add((NPC)npc.Clone());
 			}
 			return found;
@@ -423,16 +419,15 @@ namespace TShockAPI
 		{
 			Item item = new Item();
 			item.SetDefaults(0);
-			string lowerName = name.ToLowerInvariant();
+			string lowerName = name.ToLower();
 			var found = new List<int>();
 			for (int i = FirstItemPrefix; i <= LastItemPrefix; i++)
 			{
 				item.prefix = (byte)i;
-				string prefixName = item.AffixName().Trim().ToLowerInvariant();
-				string englishName = EnglishLanguage.GetPrefixById(i).ToLowerInvariant();
-				if (prefixName == lowerName || englishName == lowerName)
+				string prefixName = item.AffixName().Trim().ToLower();
+				if (prefixName == lowerName)
 					return new List<int>() { i };
-				else if (prefixName.StartsWith(lowerName) || englishName?.StartsWith(lowerName) == true) // Partial match
+				else if (prefixName.StartsWith(lowerName) // Partial match
 					found.Add(i);
 			}
 			return found;


### PR DESCRIPTION
Fix command failure on /spawnmob [mobName] and /item <item name> <stack> [prefixName], the issue was caused by incompatible references to a version of OTAPI newer than 1.3.0.7

For example: if you try to run /spawnmob unicorn, it will return command failed check logs. so you can only spawn mob by ID which was a pain in the ass having to tab out of the game and look for the mob ID. 