### PR TITLE
Version code name update

### DIFF
--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -57,7 +57,7 @@ namespace TShockAPI
 		/// <summary>VersionNum - The version number the TerrariaAPI will return back to the API. We just use the Assembly info.</summary>
 		public static readonly Version VersionNum = Assembly.GetExecutingAssembly().GetName().Version;
 		/// <summary>VersionCodename - The version codename is displayed when the server starts. Inspired by software codenames conventions.</summary>
-		public static readonly string VersionCodename = "FeyMobileBuild";
+		public static readonly string VersionCodename = "Bellatrix";
 
 		/// <summary>SavePath - This is the path TShock saves its data in. This path is relative to the TerrariaServer.exe (not in ServerPlugins).</summary>
 		public static string SavePath = "tshock";


### PR DESCRIPTION
It was called "Zombie" because the project was not being actively maintained. Before that, it was called "Mintaka" since that is a star system in the constellation of Orion, and because "TShock 4.3.21 for Terraria 1.3.4.4 on OTAPI 2.0.0.9 with compatibility for the Terraria Server API version 1.26." is a stupidly long name. Bellatrix is also a star in the constellation of Orion and seems fitting for an actively maintained mobile compatible version of the main PC repository (TShock 4.3.26 for Terraria mobile 1.3.0.7.7 on OTAPI 2.0.0.12 with compatibility for the Terraria Server API v2.1).