### PR TITLE
Removed PE Client Check - Discussion for a New Check

### DIFF
--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2293,10 +2293,10 @@ namespace TShockAPI
 			var id = args.Data.ReadInt16();
 			var owner = args.Data.ReadInt8();
 
-			if (owner > 16)
-			{
-				args.Player.Kick("Not PE Client.", true, true);
-			}
+			//if (owner > 16)
+			//{
+			//	args.Player.Kick("Not PE Client.", true, true);
+			//}
 
 			if (id < 0 || id > 400)
 				return true;


### PR DESCRIPTION
Since 1.4 clients are ports of PC Terraria, this check will not work since item statuses
I tried couple things to do this check but it didn't work, even decompiled Official Mobile Server, build OTAPI from decompiled code, build the TerrariaServerAPI, TShockAPI and other plugins from this OTAPI but the check still does not work. What we can do for implement or replace the old check?

Reference: #29